### PR TITLE
Change wording in using_namespace_std a bit.

### DIFF
--- a/using_namespace_std.md
+++ b/using_namespace_std.md
@@ -1,6 +1,6 @@
 # Why Is `using namespace std` Considered Bad Practice?
 
-`using namespace std` will import **all** of the symbols from `std` into the enclosing namespace.
+`using namespace std` will import **all** of the symbols from `std` into the current scope.
 This can easily lead to name collisions, as the standard library is filled with common names:
 `get`, `count`, `map`, `array`, etc.
 


### PR DESCRIPTION
Changed `enclosing namespace` to `current scope` in using_namespace_std.mdx. Much productive. Much contribute.
![image](https://user-images.githubusercontent.com/75364377/153067988-71a7142c-8424-4111-9777-0abcc706c16e.png)
