### PR TITLE
Add compilation_steps and header_only_templates articles

### DIFF
--- a/compilation_steps.md
+++ b/compilation_steps.md
@@ -1,0 +1,26 @@
+# How Is C/C++ Source Code Compiled?
+
+\:hash: The **preprocessor** expands macros and copy-pastes the content of included files
+at their point of inclusion. After being preprocessed, a source file no longer
+contains preprocessor directives. The result is called a _translation unit_ (TU).
+
+> :bulb: _The preprocessor merely does text replacement, it does not care about any aspect of C/C++._
+
+:ce: The **compiler** turns instructions into machine code and enforces C/C++
+syntax rules. In particular, anything that is used must be have been declared
+beforehand. The compiler only needs to know that something **exists**, not how
+it is _defined_.
+
+> :bulb: _Headers are a convenient way to expose function declarations to the compiler. Function definitions can reside in another, separately compiled TU, allowing finer control over the compilation process._
+
+As function definitions might be unavailable at this point, the compiler emits
+dummy machine code for function calls. A final step must be performed to fix those.
+
+:link: The **linker** takes all compiled TUs at once and patches the dummy calls
+emitted by the compiler. For each of those, the linker finds the compiled
+function and inserts an address to jump to when the call is performed.
+
+> :bulb: _Errors stating `undefined reference` or `unresolved external symbol` are linker errors, and they occur when the linker is unable to find a definition within the TUs it was given._
+
+The linker also packs all the compiled code into one of three file formats:
+an executable, a static library, or a dynamic link library.

--- a/template_argument_deduction.md
+++ b/template_argument_deduction.md
@@ -1,0 +1,68 @@
+# What Is Template Argument Deduction?
+
+Sometimes, it is possible to omit template arguments when using a template,
+letting the compiler infer them instead.
+
+## Template function
+?inline
+```cpp
+template<typename T>
+void print(T arg) {
+    std::cout << arg << ' ';
+}
+```
+
+## Usage
+?inline
+```cpp
+print(42);
+print("Hello");
+print<std::string>("Hi");
+```
+
+In the first two calls to `print`, no template argument is provided. Since `print`
+takes a parameter of type `T`, the compiler can match `T` to the type of
+the provided arguments: `int` for `42`, and `const char*` for `"Hello"`.
+
+The third call inhibits deduction by imposing `T`. An `std::string` is constructed
+from `"Hi"`, and a copy of it is passed to the function.
+
+The compiler cannot always deduce template parameters, notably when a template
+parameter appears only in the return type of a function:
+
+## Template function
+?inline
+```cpp
+template<class T>
+T make(int arg) {
+  return T(arg);
+}
+```
+
+## Usage
+?inline
+```cpp
+Foo foo = make<Foo>(42);
+// ok, returns Foo
+Foo bar = make(45);
+// error: cannot deduce T
+```
+
+Template parameters can be partially deduced independently of each other:
+
+## Template function
+?inline
+```cpp
+template<class T, class A>
+T make(A arg) {
+    return T(arg);
+}
+```
+
+## Usage
+?inline
+```cpp
+Foo foo = make<Foo>(42);
+// T    = Foo (explicit)
+// ArgT = int (deduced)
+```

--- a/template_instantiation.md
+++ b/template_instantiation.md
@@ -1,0 +1,36 @@
+# What Is Template Instantiation?
+
+Templates are not real entities until a piece code uses them with arguments.
+When this happens, the compiler replaces the template parameters with the
+provided arguments, deriving the generic code into specific code.
+
+The generic code needs to be available in any translation unit that uses it. This
+is why templates are typically declared **and** defined entirely in headers.
+
+## Template function
+?inline
+```cpp
+template<typename T>
+void print(T arg) {
+    std::cout << arg << ' ';
+}
+```
+
+## Usage
+?inline
+```cpp
+print(42);
+print("Hello");
+```
+
+On the first call to `print`, the compiler substitutes `T` for `int` in the
+template code, _instantiating_ it into a new function. The second call to `print`
+causes `T` to be substituted for `const char*`, instantiating the template again.
+
+Here, `T` is said to be _deduced_: the compiler infers `T` from the type of the
+argument to `print`.
+
+**Output:**
+```
+42 Hello 
+```


### PR DESCRIPTION
A couple articles about stuff that I find myself explaining a lot on TCCPP:

- what's really going on when you compile stuff
- why must templates reside in headers only

I tried to keep it short but I'm afraid it's a bit long. Any way I can test what it would look like and edit accordingly?